### PR TITLE
Rename Truffel to Truffle

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,7 +201,7 @@ A curated list of awesome resources, learning materials, tools, frameworks, plat
   * [Java AOT (Ahead of Time) Compilation](https://2016.javazone.no/program/java-aot-compilation).
   * [MetaScala: A Tiny DIY JVM](https://skillsmatter.com/skillscasts/4916-metascala-a-tiny-diy-jvm) - Metascala is a tiny metacircular Java Virtual Machine (JVM) written in the Scala programming language.
   * [Meta-Tracing, RPython and PyPy](https://ia601503.us.archive.org/32/items/vmss16/bolz.pdf).
-  * [One VM to Rule Them All, One VM to Bind Them](https://www.youtube.com/watch?v=FJY96_6Y3a4) - Tutorial on the Truffel technology.
+  * [One VM to Rule Them All, One VM to Bind Them](https://www.youtube.com/watch?v=FJY96_6Y3a4) - Tutorial on the Truffle technology.
   * [Programming Should Eat Itself](https://www.youtube.com/watch?v=SrKj4hYic5A) - StrangeLoop Talk on Reflective Programming and Kenichi Asai's Black Programming Language.
   * [Python, Linkers and Virtual Memory - PYCON US](https://www.youtube.com/watch?v=twQKAoq2OPE).
   * [Reverse Engineering the MOS 6502 CPU](https://youtube.com/watch?v=fWqBmmPQP40).
@@ -227,7 +227,7 @@ A curated list of awesome resources, learning materials, tools, frameworks, plat
     + [Part 3 - LLVM](http://eli.thegreenplace.net/2017/adventures-in-jit-compilation-part-3-llvm/).
     + [Part 4 - In Python](http://eli.thegreenplace.net/2017/adventures-in-jit-compilation-part-4-in-python/).
   * [ALIVe: Automatic LLVM InstCombine Verifier](https://blog.regehr.org/archives/1170).
-  * [Graal and Truffel](https://blog.plan99.net/graal-truffle-134d8f28fb69) - Obscure research project could radically accelerate innovation in programming language design.
+  * [Graal and Truffle](https://blog.plan99.net/graal-truffle-134d8f28fb69) - Obscure research project could radically accelerate innovation in programming language design.
     + Discussions: [Reddit](https://redd.it/4tm4mj).
   * [How to Compile with Continuations](http://matt.might.net/articles/cps-conversion/).
   * [Interpreter, Compiler and JIT](https://nickdesaulniers.github.io/blog/2015/05/25/interpreter-compiler-jit/).
@@ -264,7 +264,7 @@ A curated list of awesome resources, learning materials, tools, frameworks, plat
   * [Metacompiler Tutorial, Part 1](http://www.bayfronttechnologies.com/mc_tutorial.html).
   * [Project: A Programming Language](http://eloquentjavascript.net/11_language.html) - Chapter 11 from the book _Eloquent JavaScript_, 2nd Edition.
   * [Write You a Haskell](http://dev.stephendiehl.com/fun/).
-  * [Writing a Language in Truffel](http://cesquivias.github.io/tags/truffle.html) - Interpreter development tutorial using Truffel, by Cristian Esquivias.
+  * [Writing a Language in Truffle](http://cesquivias.github.io/tags/truffle.html) - Interpreter development tutorial using Truffle, by Cristian Esquivias.
 
 
 ### Community Discussions
@@ -336,7 +336,7 @@ A curated list of awesome resources, learning materials, tools, frameworks, plat
 ### Graal
 
   * [Graal](https://github.com/graalvm/graal) - High-Performance Polyglot Runtime.
-  * [Graal Core](https://github.com/graalvm/graal-core) - Compiler and Truffel Partial Evaluator.
+  * [Graal Core](https://github.com/graalvm/graal-core) - Compiler and Truffle Partial Evaluator.
   * [Graal VM](https://github.com/graalvm/graalvm) - Graal's multi-language VM distribution.
 
 ### Haskell


### PR DESCRIPTION
Oracle's language development framework for the GraalVM is actually called *Truffle*.

Please fill in this template:

- [x] Use a meaningful title for the pull request. Include the name of the resource added.
- [x] Add a short sentence on why do you think the resource you're adding is awesome!
- [x] Make sure your addition maintains the alphabtical order of the list.
- [x] Make sure your addition contains a description besides the link.
