### PR TITLE
Add dnlib and dnSpy

### DIFF
--- a/README.md
+++ b/README.md
@@ -315,6 +315,8 @@ A curated list of awesome resources, learning materials, tools, frameworks, plat
 ### CLR
 
   * [Cecil](http://www.mono-project.com/docs/tools+libraries/libraries/Mono.Cecil/) - Library to generate and inspect programs and libraries in the ECMA CIL format.
+  * [dnlib](https://github.com/0xd4d/dnlib) - Library to manipulate .NET assemblies, including obfuscated assemblies.
+  * [dnSpy](https://github.com/0xd4d/dnSpy) - Graphical debugger and .NET assembly editor (Windows).
   * [DotNetPELib](https://github.com/LADSoft/DotNetPELib) - Library to read and write .net assemblies in C++11
   * [ILSpy](http://ilspy.net) - .NET Decompiler.
   * [Reflector](http://www.red-gate.com/products/dotnet-development/reflector/) - .NET Decompiler.


### PR DESCRIPTION
dnlib is a library like Mono.Cecil but handles the more obscure cases that cause Cecil to fail so it can be used on obfuscated code.

dnSpy is a useful tool for disassembly/decompiling/debugging without source. Very handy to have if outputting .NET assemblies.

Please fill in this template:

- [x] Use a meaningful title for the pull request. Include the name of the resource added.
- [x] Add a short sentence on why do you think the resource you're adding is awesome!
- [x] Make sure your addition maintains the alphabtical order of the list.
- [x] Make sure your addition contains a description besides the link.
