### PR TITLE
Add IL2CPU in serious projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -411,6 +411,7 @@ _This section aims at listing code projects of Compilers, Interpreters, Translat
   * [Frege's Compiler](https://github.com/Frege/frege) - JVM-based Compiler for the Frege Programming Language.
   * [Gluon's Compiler](https://github.com/gluon-lang/gluon) - Embedded Language Compiler written in Rust.
   * [HHVM](https://github.com/facebook/hhvm) - Virtual Machine for running programs written in Hack and PHP.
+  * [IL2CPU](https://github.com/CosmosOS/IL2CPU) .NET IL Code to Assembly Language
   * [Lily's Interpreter](https://github.com/FascinatedBox/lily).
   * [Lua's Interpreter](https://github.com/LuaDist/lua) - Official Lua Language Interperter.
     + [Lua's Annotated Source Code](http://stevedonovan.github.io/lua-5.1.4/) - Annotated source code of the Lua Programming Language Interpreter v5.1.4.


### PR DESCRIPTION
IL2CPU is a compiler for .NET IL code to compile to assembly language for direct booting. IL2CPU creates NASM style assembly ready to assemble with NASM.

Please fill in this template:

- [x] Use a meaningful title for the pull request. Include the name of the resource added.
- [x] Add a short sentence on why do you think the resource you're adding is awesome!
- [x] Make sure your addition maintains the alphabtical order of the list.
- [x] Make sure your addition contains a description besides the link.