### PR TITLE
Add Python xdis and uncompyle6

### DIFF
--- a/README.md
+++ b/README.md
@@ -352,7 +352,7 @@ A curated list of awesome resources, learning materials, tools, frameworks, plat
   * [IRHudra](http://mrale.ph/irhydra/2/) - Tool for displaying intermediate representations used by V8 and Dart VM optimizing compilers.
     + [GitHub Repo](https://github.com/mraleph/irhydra).
   * [JISON](http://zaa.ch/jison/docs/) - Context-free grammar parser generator for JavaScript.
-    + [GerHobbelt/jison](https://github.com/GerHobbelt/jison) - active fork of jison with bunch of improvements.  
+    + [GerHobbelt/jison](https://github.com/GerHobbelt/jison) - active fork of jison with bunch of improvements.
   * [Nearley](https://github.com/Hardmath123/nearley) - Simple, fast, powerful parser toolkit for JavaScript.
   * [Ohm](https://github.com/harc/ohm) - A library and language for building parsers, interpreters, compilers, etc.
   * [PEG.js](https://pegjs.org) - Simple parser generator for JavaScript.
@@ -381,6 +381,8 @@ A curated list of awesome resources, learning materials, tools, frameworks, plat
   * [PyParsing](http://pyparsing.wikispaces.com/) - Alternative approach to creating and executing simple grammars, vs. the traditional lex/yacc approach, or the use of regular expressions.
   * [RPLY](https://github.com/alex/rply) - Port of the PLY project to RPython.
   * [RPython](https://rpython.readthedocs.io/en/latest/) - RPython is a framework for the implementatation of dynamic languages.
+  * [xdis](https://pypi.org/project/xdis/) - Cross-Python's Disassembler, Bytecode, and Magic Number Manipulation package.
+  * [uncompyle6](https://pypi.org/project/uncompyle6/) - A native Python cross-version decompiler and fragment decompiler.
 
 #### Lists of Python Parsing Tools
 


### PR DESCRIPTION
Please fill in this template:

- [x] Use a meaningful title for the pull request. Include the name of the resource added.
- [x] Add a short sentence on why do you think the resource you're adding is awesome!
- [x] Make sure your addition maintains the alphabtical order of the list.
- [x] Make sure your addition contains a description besides the link.

For xdis: although "dis" handles within a given version of python there is nothing else out there that ecompases all released bytecode (and PyPy), Whereas in python disassembly and bytecode handling may get better over time for the current version, improvements here go backwards and extend to all prior bytecode versions. So you can manipulate back-level bytecode with the same convenience as current bytecode. But in addition to this it has extensive knowledge about Python magic numbers, and how to convert them into Python versions. And a facility for creating disassembly in a form that is amenable for a bytecode assembler. (I have a specific one in mind which is also unique, but that's another project though that I haven't listed.)

With regards to the bytecode decompiler it is awesome because it handles something like 25 versions of Python handling its language drift over. the years. It  is demonstrably the best bytecode decompiler for Python that exists. (We check this by running over the Python's internal test suite). 
