### PR TITLE
Add Maxine VM to JVMs

### DIFF
--- a/README.md
+++ b/README.md
@@ -473,6 +473,7 @@ _This section aims at listing code projects of Compilers, Interpreters, Translat
     + [Kaffe](https://github.com/kaffe/kaffe).
     + [JamVM](http://jamvm.sourceforge.net) - [GitHub project mirror](https://github.com/cfriedt/jamvm).
     + [Apache Harmony](https://harmony.apache.org/).
+    + [Maxine VM](https://github.com/beehive-lab/Maxine-VM).
     + [Other JVM Runtimes](https://en.wikipedia.org/wiki/List_of_Java_virtual_machines).
 
 


### PR DESCRIPTION
Maxine VM is a metacircular VM that supports Java.
It is compatible with the latest OpenJDK 8 classpath, it is modular and features tiered JIT compilation.
It is oriented towards research rather than production use.

Link to github repo https://github.com/beehive-lab/Maxine-VM

Please fill in this template:

- [ ] Use a meaningful title for the pull request. Include the name of the resource added.
- [ ] Add a short sentence on why do you think the resource you're adding is awesome!
- [ ] Make sure your addition maintains the alphabtical order of the list.
- [ ] Make sure your addition contains a description besides the link.
