### PR TITLE
Add Compiler Explorer to section educational

### DIFF
--- a/README.md
+++ b/README.md
@@ -434,6 +434,7 @@ _This section aims at listing code projects of Compilers, Interpreters, Translat
     + Discussions: [HN](https://news.ycombinator.com/item?id=8558822).
   * [CarpVM](https://github.com/tekknolagi/carp) - Experimental VM implementation in C.
   * [Charly](https://github.com/charly-lang/charly) - Interpreter for a dynamically typed language written in Crystal.
+  * [Compiler Explorer](https://godbolt.org/) - Run compilers interactively from your web browser and interact with the assembly. Source code found on [GitHub](https://github.com/mattgodbolt/compiler-explorer).
   * [Dale](https://github.com/tomhrr/dale) - Lisp-flavoured C: a system programming language.
   * [EasyLang](https://github.com/erhanbaris/EasyLang) - Easy Programming Language / VM.
   * [Eschelle](https://github.com/Eschelle/Eschelle) - Open source cross platform multi-paradigm language with VM & JIT


### PR DESCRIPTION
Please fill in this template:

- [x] Use a meaningful title for the pull request. Include the name of the resource added.
  _Tool and section mentioned._
- [x] Add a short sentence on why do you think the resource you're adding is awesome!
  _It helps understanding and looking at the output of various compilers quickly and one is able to test different compilers without the hassle of installing them all. Furthermore, it's possible to test different compiler options and various versions of the same compiler easily. And it has a Vim-mode which is awesome._
- [x] Make sure your addition maintains the alphabtical order of the list.
- [x] Make sure your addition contains a description besides the link.

I would split educational and toy projects or maybe I misunderstood the word "educational". It feels awkward adding Compiler Explorer to section toy project :) Would you move it to "Serious Projects" under _Compilers and Interpreters_ or "Language Agnostic" under _Tools and Frameworks_?