### PR TITLE
Add Strumenta Community

### DIFF
--- a/README.md
+++ b/README.md
@@ -490,6 +490,9 @@ _This section aims at listing code projects of Compilers, Interpreters, Translat
 
   * [/r/Compilers](https://www.reddit.com/r/Compilers) - Subreddit community about the theory and development of compilers.
   * [/r/ProgrammingLanguages](https://reddit.com/r/ProgrammingLanguages) - Subreddit community that is dedicated to discussion of programming languages, programming language theory, design, their syntax and compilers.
+  * [Strumenta Community](https://strumenta.community/) - A community about language engineering (DSLs, parsers, compilers, interpreters, tooling) open to practicioners, researchers, and enthusiasts (currently invite-only).
+
+
 
 
 ## Verticals


### PR DESCRIPTION
Because it's hacktoberfest time and I don't want this to feel like gratuitous spam, feel free to close the PR and add the line yourself only if you think it makes sense :)

[Strumenta Community](https://strumenta.community/) is a very new, fast-growing community about language engineering. The forum already counts about 300 members, including some well-known names. They also organise weekly virtual meetups. It is currently invite-only to keep the traffic controlled: if this policy goes against the spirit of this list, feel free to reject. Nonetheless, I believe it's a pretty lively and interesting place for compiler enthusiasts, hence why I am opening this PR!

Full Disclosure: I know one of the founders :)