### PR TITLE
Add coollang-2020-fs to Educational and Toy Projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -434,6 +434,7 @@ _This section aims at listing code projects of Compilers, Interpreters, Translat
     + Discussions: [HN](https://news.ycombinator.com/item?id=8558822).
   * [CarpVM](https://github.com/tekknolagi/carp) - Experimental VM implementation in C.
   * [Charly](https://github.com/charly-lang/charly) - Interpreter for a dynamically typed language written in Crystal.
+  * [coollang-2020-fs](https://github.com/mykolav/coollang-2020-fs) - Compiler of a small Scala subset into x86-64 assembly implemented in F#.
   * [Dale](https://github.com/tomhrr/dale) - Lisp-flavoured C: a system programming language.
   * [EasyLang](https://github.com/erhanbaris/EasyLang) - Easy Programming Language / VM.
   * [Eschelle](https://github.com/Eschelle/Eschelle) - Open source cross platform multi-paradigm language with VM & JIT


### PR DESCRIPTION
coollang-2020-fs compiles a small but interesting Scala subset into x86-64 assembly.

- It compiles down to x86-64 assembly. Then invokes GNU as and ld to produce a native executable.
- The language is simple but not too simple. A lot of mini-compilers have languages with functions, primitive values and not much else. This project's language has classes, inheritance, virtual dispatch, and even a very simple form of pattern matching.