### PR TITLE
Add QBE IR for Rust bullet

### DIFF
--- a/README.md
+++ b/README.md
@@ -395,6 +395,7 @@ A curated list of awesome resources, learning materials, tools, frameworks, plat
   * [Nom](https://github.com/Geal/nom) - Parser Combinator Framework.
   * [PEG](https://github.com/kevinmehall/rust-peg) - PEG Parser Generator.
   * [Pest](https://github.com/pest-parser/pest) - PEG Parser Generator.
+  * [QBE](https://github.com/garritfra/qbe-rs) - QBE IR for Rust
   * [RLS](https://github.com/rust-lang-nursery/rls) - The Rust Language Server implementation (aka RLS).
 
 ## Compilers and Interpreters


### PR DESCRIPTION
We initially wrote this library for the [Antimony](https://github.com/antimony-lang/antimony) programming language, until it became its own crate. If you're writing a QBE backend in Rust, this is the way to go!

Please fill in this template:

- [x] Use a meaningful title for the pull request. Include the name of the resource added.
- [x] Add a short sentence on why do you think the resource you're adding is awesome!
- [x] Make sure your addition maintains the alphabtical order of the list.
- [x] Make sure your addition contains a description besides the link.
